### PR TITLE
Preparse xml to avoid code multiline definition

### DIFF
--- a/src/lib/html/prepare-html.js
+++ b/src/lib/html/prepare-html.js
@@ -1,3 +1,5 @@
+const { parseDOM } = require('htmlparser2');
+const { getOuterHTML } = require('domutils');
 const VOID_ELEMENTS = require('./voidelements.json');
 
 // `<sergey-slot ...args />` -> `<sergey-slot ...args></sergey-slot>`
@@ -23,5 +25,6 @@ module.exports = (html_) => {
       html = html.replace(original, newTagContent);
     });
 
+  html = getOuterHTML(parseDOM(html));
   return html;
 };


### PR DESCRIPTION
I've some troubles with muiltiline code definitions like:

```html
<div
  foo="bar">
  <sergey-slot />
</div>
```

This PR fixes by standardizing the html: 

```html
<div foo="bar">
  <sergey-slot></sergey-slot>
</div>
```